### PR TITLE
fix(formit): кастомный successMessage в AJAX-ответе

### DIFF
--- a/core/components/fetchit/docs/changelog.txt
+++ b/core/components/fetchit/docs/changelog.txt
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Custom `successMessage` snippet parameter is now passed to FormIt placeholders in `handleFormIt()`.
+
 ## [1.1.2] - 2023-11-11
 
 ### Added

--- a/core/components/fetchit/docs/changelog.txt
+++ b/core/components/fetchit/docs/changelog.txt
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Custom `successMessage` snippet parameter is now passed to FormIt placeholders in `handleFormIt()`.
+- Custom `successMessage` snippet parameter is now used in the AJAX success response.
 
 ## [1.1.2] - 2023-11-11
 

--- a/core/components/fetchit/model/fetchit.class.php
+++ b/core/components/fetchit/model/fetchit.class.php
@@ -176,6 +176,10 @@ class FetchIt
             ? $scriptProperties['placeholderPrefix']
             : 'fi.';
 
+        if (!empty($scriptProperties['successMessage'])) {
+            $this->modx->setPlaceholder($plPrefix . 'successMessage', $scriptProperties['successMessage']);
+        }
+
         $errors = array();
         foreach ($scriptProperties['fields'] as $k => $v) {
             if (isset($this->modx->placeholders[$plPrefix . 'error.' . $k])) {

--- a/core/components/fetchit/model/fetchit.class.php
+++ b/core/components/fetchit/model/fetchit.class.php
@@ -176,10 +176,6 @@ class FetchIt
             ? $scriptProperties['placeholderPrefix']
             : 'fi.';
 
-        if (!empty($scriptProperties['successMessage'])) {
-            $this->modx->setPlaceholder($plPrefix . 'successMessage', $scriptProperties['successMessage']);
-        }
-
         $errors = array();
         foreach ($scriptProperties['fields'] as $k => $v) {
             if (isset($this->modx->placeholders[$plPrefix . 'error.' . $k])) {
@@ -205,9 +201,11 @@ class FetchIt
                 : 'fetchit_err_has_errors';
             $status = 'error';
         } else {
-            $message = isset($this->modx->placeholders[$plPrefix . 'successMessage'])
-                ? $this->modx->placeholders[$plPrefix . 'successMessage']
-                : 'fetchit_success_submit';
+            $message = !empty($scriptProperties['successMessage'])
+                ? $scriptProperties['successMessage']
+                : (isset($this->modx->placeholders[$plPrefix . 'successMessage'])
+                    ? $this->modx->placeholders[$plPrefix . 'successMessage']
+                    : 'fetchit_success_submit');
             $status = 'success';
         }
 


### PR DESCRIPTION
Кастомный `successMessage` из вызова сниппета FetchIt терялся при успешной
отправке формы. `handleFormIt()` читал только `fi.successMessage` из
placeholders MODX, а FormIt в AJAX-потоке placeholder не всегда выставляет.
Ответ уходил в дефолтный ключ лексикона `fetchit_success_submit`.

В success-ветке сообщение берётся по цепочке: сначала `scriptProperties`,
затем placeholder FormIt, затем дефолт лексикона. `scriptProperties` уже
хранит конфиг сниппета в сессии (`fetchit.php`), это прямой источник
пользовательского текста.

`validation_error_message` не трогали: FormIt выставляет этот placeholder
при ошибках валидации и может раскрыть `[[+errors]]` в шаблоне.

Fixes GulomovCreative/FetchIt#5