### PR TITLE
fix(session): Prevent PDO serialization fatal on MODX 3.2.2+

### DIFF
--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -11,7 +11,7 @@ if (!defined('MODX_CORE_PATH')) {
 return [
     'name' => 'FetchIt',
     'name_lower' => 'fetchit',
-    'version' => '3.1.2',
+    'version' => '3.1.3',
     'release' => 'pl',
     // Install package to site right after build
     'install' => true,

--- a/core/components/fetchit/docs/changelog.txt
+++ b/core/components/fetchit/docs/changelog.txt
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2026-07-21
+
+### Fixed
+
+- Fatal error `Serialization of 'PDO' is not allowed` on frontend with MODX 3.2.2+ / PHP 8.3+ (#17).
+  Action properties are no longer stored with the FetchIt instance; custom snippets should use `$modx->services->get('FetchIt')`.
+
 ## [3.1.2] - 2023-11-11
 
 ### Added

--- a/core/components/fetchit/elements/snippets/fetchit.php
+++ b/core/components/fetchit/elements/snippets/fetchit.php
@@ -43,15 +43,7 @@ if (preg_match('#<form.*?data-fetchit=(?:"|\')(.*?)(?:"|\')#i', $content, $match
 }
 
 $FetchIt->loadScript($action);
-
-// Save snippet properties
-if (!empty(session_id())) {
-    // ... to user`s session
-    $_SESSION['FetchIt'][$action] = $scriptProperties;
-} else {
-    // ... to cache file
-    $modx->cacheManager->set('fetchit/props_' . $action, $scriptProperties, 3600);
-}
+$FetchIt->saveActionProperties($action, $scriptProperties);
 
 // Call snippet for preparation of form
 $action = !empty($_SERVER['HTTP_X_FETCHIT_ACTION'])

--- a/core/components/fetchit/src/FetchIt.php
+++ b/core/components/fetchit/src/FetchIt.php
@@ -4,7 +4,7 @@ namespace FetchIt;
 
 class FetchIt
 {
-    public $version = '3.1.2';
+    public $version = '3.1.3';
     /** @var modX $modx */
     public $modx;
     /** @var array $config */
@@ -116,6 +116,48 @@ class FetchIt
 
 
     /**
+     * Persist snippet properties for AJAX process(); strip non-serializable values (#17).
+     *
+     * @param string $action
+     * @param array $scriptProperties
+     */
+    public function saveActionProperties($action, array $scriptProperties)
+    {
+        foreach ($scriptProperties as $key => $value) {
+            if (is_object($value) || is_resource($value)) {
+                unset($scriptProperties[$key]);
+            }
+        }
+
+        if (!empty(session_id())) {
+            $_SESSION['FetchIt'][$action] = $scriptProperties;
+        } else {
+            $this->modx->cacheManager->set('fetchit/props_' . $action, $scriptProperties, 3600);
+        }
+    }
+
+
+    /**
+     * Stored action properties, or null if missing.
+     *
+     * @param string $action
+     * @return array|null
+     */
+    public function getActionProperties($action)
+    {
+        $stored = !empty(session_id())
+            ? (isset($_SESSION['FetchIt'][$action]) ? $_SESSION['FetchIt'][$action] : null)
+            : $this->modx->cacheManager->get('fetchit/props_' . $action);
+
+        if (empty($stored) || !is_array($stored)) {
+            return null;
+        }
+
+        return $stored;
+    }
+
+
+    /**
      * Loads snippet for form processing
      *
      * @param $action
@@ -125,16 +167,16 @@ class FetchIt
      */
     public function process($action, array $fields = array())
     {
-        $scriptProperties = !empty(session_id())
-            ? @$_SESSION['FetchIt'][$action]
-            : $this->modx->cacheManager->get('fetchit/props_' . $action);
-
-        if (empty($scriptProperties)) {
+        $stored = $this->getActionProperties($action);
+        if ($stored === null) {
             return $this->error('fetchit_err_action_nf');
         }
 
-        $scriptProperties['fields'] = $fields;
-        $scriptProperties['FetchIt'] = $this;
+        // Do not set FetchIt=>$this here (PDO in session, #17).
+        // Custom snippets: $modx->services->get('FetchIt').
+        $scriptProperties = array_merge($stored, array(
+            'fields' => $fields,
+        ));
 
         $name = $scriptProperties['snippet'];
         $set = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetchit",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetchit",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "ISC",
       "dependencies": {
         "notyf": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchit",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "",
   "type": "module",
   "main": ".assets/components/fetchit/js/fetchit.js",


### PR DESCRIPTION
Stop putting the FetchIt instance into FormIt/snippet `scriptProperties` and harden how action properties are persisted for AJAX submits.

On MODX 3.2.2 + PHP 8.3, `session_write_close()` fatals with `Serialization of 'PDO' is not allowed` whenever a frontend template calls FetchIt. The instance holds `modX`, which holds PDO; once that graph lands in `$_SESSION`, the response cannot finish. Admin still works because it never runs the snippet.

Also centralize save/load in `saveActionProperties()` / `getActionProperties()` and strip objects/resources before writing to session or cache, so the same failure cannot return via Fenom or other object-bearing props.

**Breaking for custom snippets:** `$scriptProperties['FetchIt']` is no longer injected. Use `$modx->services->get('FetchIt')` instead (already registered in `bootstrap.php`).

Fixes #17