### PR TITLE
fix(session): Prevent PDO serialization fatal (1.x)

### DIFF
--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -11,7 +11,7 @@ if (!defined('MODX_CORE_PATH')) {
 return [
     'name' => 'FetchIt',
     'name_lower' => 'fetchit',
-    'version' => '1.1.2',
+    'version' => '1.1.3',
     'release' => 'pl',
     // Install package to site right after build
     'install' => true,

--- a/core/components/fetchit/docs/changelog.txt
+++ b/core/components/fetchit/docs/changelog.txt
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fatal error `Serialization of 'PDO' is not allowed` on frontend with PHP 8.3+ (#17). Action properties are stripped of objects/resources before session/cache write; `$scriptProperties['FetchIt']` is no longer injected — use `$modx->getService('fetchit', 'FetchIt', MODX_CORE_PATH . 'components/fetchit/model/', [])`.
 - Form-level success and validation messages now update in the form on AJAX submit via `[data-success]` and `[data-validation-error]` ([#11]). Custom templates need these attributes instead of `[[+fi.success:…]]` conditionals for AJAX.
 - Whitespace-only FormIt field errors (e.g. `fi.error.email`) no longer mark the form as failed ([#10]). Placeholders are sanitized with `strip_tags` and `html_entity_decode`; blank `validation_error_message` falls back to the lexicon key.
 - PHP 8 warning for undefined `$_SESSION['fetchit_called']` in `registerScript()` ([#7], [#9]).

--- a/core/components/fetchit/model/fetchit.class.php
+++ b/core/components/fetchit/model/fetchit.class.php
@@ -2,7 +2,7 @@
 
 class FetchIt
 {
-    public $version = '1.1.2';
+    public $version = '1.1.3';
     /** @var modX $modx */
     public $modx;
     /** @var array $config */
@@ -127,11 +127,19 @@ class FetchIt
 
 
     /**
+     * Persist snippet properties for AJAX process(); strip non-serializable values (#17).
+     *
      * @param string $action
      * @param array $scriptProperties
      */
     public function storeActionProperties($action, array $scriptProperties)
     {
+        foreach ($scriptProperties as $key => $value) {
+            if (is_object($value) || is_resource($value)) {
+                unset($scriptProperties[$key]);
+            }
+        }
+
         if (!empty(session_id())) {
             if (!isset($_SESSION['FetchIt'])) {
                 $_SESSION['FetchIt'] = array();
@@ -149,6 +157,8 @@ class FetchIt
 
 
     /**
+     * Stored action properties, or null if missing / invalid.
+     *
      * @param string $action
      *
      * @return array|null
@@ -156,10 +166,16 @@ class FetchIt
     public function loadActionProperties($action)
     {
         if (!empty(session_id()) && isset($_SESSION['FetchIt'][$action])) {
-            return $_SESSION['FetchIt'][$action];
+            $stored = $_SESSION['FetchIt'][$action];
+        } else {
+            $stored = $this->modx->cacheManager->get($this->getActionPropertiesCacheKey($action));
         }
 
-        return $this->modx->cacheManager->get($this->getActionPropertiesCacheKey($action));
+        if (empty($stored) || !is_array($stored)) {
+            return null;
+        }
+
+        return $stored;
     }
 
 
@@ -173,14 +189,16 @@ class FetchIt
      */
     public function process($action, array $fields = array())
     {
-        $scriptProperties = $this->loadActionProperties($action);
-
-        if (empty($scriptProperties)) {
+        $stored = $this->loadActionProperties($action);
+        if ($stored === null) {
             return $this->error('fetchit_err_action_nf');
         }
 
-        $scriptProperties['fields'] = $fields;
-        $scriptProperties['FetchIt'] = $this;
+        // Do not set FetchIt=>$this here (PDO in session, #17).
+        // Custom snippets: $modx->getService('fetchit', 'FetchIt', MODX_CORE_PATH . 'components/fetchit/model/', []).
+        $scriptProperties = array_merge($stored, array(
+            'fields' => $fields,
+        ));
 
         $name = $scriptProperties['snippet'];
         $set = '';


### PR DESCRIPTION
Port the #17 session/PDO fix to the MODX 2 / 1.x line.

`process()` no longer assigns `$scriptProperties['FetchIt'] = $this`, and action properties are saved through `saveActionProperties()` which drops objects/resources before touching `$_SESSION` or the cache.

**Breaking for custom snippets:** use `$modx->getService('fetchit', 'FetchIt', ...)` instead of the injected `$FetchIt` property.

Refs #17